### PR TITLE
Add mkimage binary to builders

### DIFF
--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -34,6 +34,7 @@
     - python-keyring
     - python-pyelftools
     - python-requests
+    - u-boot-tools
     - unzip
     - zlib1g:i386
   tags:


### PR DESCRIPTION
Requested by arnd to fix
https://storage.kernelci.org/next/next-20170217/mips-generic_defconfig/build.log