### PR TITLE
Add system gitconfig file

### DIFF
--- a/roles/common/files/gitconfig
+++ b/roles/common/files/gitconfig
@@ -1,0 +1,2 @@
+[core]
+    abbrev = 12

--- a/roles/common/tasks/mirrors.yml
+++ b/roles/common/tasks/mirrors.yml
@@ -1,4 +1,13 @@
 ---
+- name: Copy the gitconfig file
+  copy:
+    src: "gitconfig"
+    dest: "/etc/gitconfig"
+    owner: root
+    group: root
+  tags:
+    - gitconfig
+
 - name: Create the mirrors directory
   file:
     path: "/srv/mirrors"


### PR DESCRIPTION
  * Instead of running git config command on each build, use
    a system gitconfig file we can use to better configure git
    behavior.