### PR TITLE
packages: fix JRE for debian/stretch

### DIFF
--- a/roles/common/tasks/packages.yml
+++ b/roles/common/tasks/packages.yml
@@ -14,7 +14,7 @@
     - packages
 
 - name: Install packages for Ubuntu and Debian Stretch
-  when: (ansible_distribution == "Debian" and ansible_distribution_version == "stretch/sid") or
+  when: (ansible_distribution == "Debian" and ansible_distribution_release == "stretch") or
         (ansible_distribution == "Ubuntu" and ansible_distribution_release == "xenial")
   apt:
     pkg: "{{ item }}"


### PR DESCRIPTION
The JRE install was not working for debian stretch for 2 reasons:

1) wrong ansible keyword for distribution release
2) "stretch/sid" doesn't match, needs to be "stretch"

Fix both.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>