### PR TITLE
Add terbium to hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -2,6 +2,7 @@
 master
 builder01
 builder02
+terbium
 
 [linaro]
 builder03


### PR DESCRIPTION
Add terbium the list in the hosts file.  This is a regular builder on
terbium.collabora.co.uk.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>