### PR TITLE
Fix k8s service-account tempfile creation

### DIFF
--- a/roles/common/tasks/k8s.yml
+++ b/roles/common/tasks/k8s.yml
@@ -68,12 +68,23 @@
     - gcloud-auth
     - gcloud
     - k8s
-  become: yes
-  become_user: buildslave
   tempfile:
     state: file
     suffix: ".json"
   register: gcloud_keyfile
+
+- name: Change ownership of temp file for service-account key
+  tags:
+    - gcloud-auth
+    - gcloud
+    - k8s
+  file:
+    path: "{{ gcloud_keyfile.path }}"
+    state: file
+    owner: buildslave
+    group: buildslave
+    mode: 0644
+  when: gcloud_keyfile.path is defined
 
 - name: Copy gcloud service-account key
   tags:


### PR DESCRIPTION
The temporary file for the service-account key is created within a
temporary directory created by the "kernelci" user, but the
"buildslave" user doesn't have write permissions there.  Fix that by
first creating it with the default "kernelci" user and then change
ownership to "buildslave".

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>