### PR TITLE
Fix creation of /root/.ssh directory

### DIFF
--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -72,7 +72,7 @@
 # default when there is no deploy_user or admin_user defined.
 
 - name: Create the root user ssh dir
-  when: deploy_user is not defined and admin_user is not defined
+  when: deploy_user is not defined
   file:
     path: "/root/.ssh"
     state: directory


### PR DESCRIPTION
Fix the conditional so the directory is created when the
authorized_keys file is needed.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>