### PR TITLE
Add new Jenkins hosts (-usa and -europe)

### DIFF
--- a/hosts
+++ b/hosts
@@ -30,6 +30,8 @@ azure-kernelci4
 azure-kernelci6
 azure-kernelci7
 azure-kernelci9
+azure-kernelci-jenkins-usa
+azure-kernelci-jenkins-europe
 
 [kernel-builders:children]
 collabora


### PR DESCRIPTION
Add entries for the new Jenkins hosts which are used to run jobs in
various Kubernetes clusters.

Signed-off-by: Guillaume Tucker <guillaume.tucker@collabora.com>