### PR TITLE
users.yml: Add fixed uid for buildslave user

### DIFF
--- a/roles/common/tasks/users.yml
+++ b/roles/common/tasks/users.yml
@@ -121,6 +121,7 @@
     state: present
     password: "{{ buildslave_password }}"
     system: yes
+    uid: 996
   tags:
     - install
     - user


### PR DESCRIPTION
Some builders have separate /data directories that are not deployed
by ansible, so uid mismatch causing permission issues.
Also ChromeOS rootfs job expect uid to be specific value.
This commit will make buildslave uid persistent.

Signed-off-by: Denys Fedoryshchenko <denys.f@collabora.com>